### PR TITLE
EG-446 approval summary connector

### DIFF
--- a/app/connectors/ApprovalConnector.scala
+++ b/app/connectors/ApprovalConnector.scala
@@ -31,7 +31,7 @@ class ApprovalConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig)
 
     import connectors.httpParsers.ApprovalHttpParser.getApprovalSummaryListHttpReads
 
-    val summaryEndPoint: String = appConfig.externalGuidanceBaseUrl + "/external-guidance/approval/list"
+    val summaryEndPoint: String = appConfig.externalGuidanceBaseUrl + "/external-guidance/approval"
 
     httpClient.GET[RequestOutcome[List[ApprovalProcessSummary]]](summaryEndPoint, Seq.empty, Seq.empty)
   }

--- a/app/connectors/ApprovalConnector.scala
+++ b/app/connectors/ApprovalConnector.scala
@@ -18,27 +18,23 @@ package connectors
 
 import config.AppConfig
 import javax.inject.{Inject, Singleton}
-import models.{RequestOutcome, ApprovalResponse, ApprovalProcessSummary}
-import models.ApprovalStatus._
+import models.{ApprovalProcessSummary, ApprovalResponse, RequestOutcome}
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
-import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ApprovalConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig) {
 
-  //noinspection ScalaStyle
-  val stubProcessList = List(
-    ApprovalProcessSummary("ext90002", "Telling hmrc about extra income", LocalDate.of(2020, 2, 20), SubmittedFor2iReview),
-    ApprovalProcessSummary("ext90003", "EU exit guidance", LocalDate.of(2020, 2, 7), SubmittedForFactCheck),
-    ApprovalProcessSummary("ext90004", "Find a lost user ID and password", LocalDate.of(2019, 12, 13), SubmittedFor2iReview),
-    ApprovalProcessSummary("ext90005", "Apply for a marriage licence", LocalDate.of(2019, 12, 12), SubmittedFor2iReview)
-  )
+  def approvalSummaries(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[RequestOutcome[List[ApprovalProcessSummary]]] = {
 
-  def approvalSummaries(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[RequestOutcome[List[ApprovalProcessSummary]]] =
-    Future.successful(Right(stubProcessList))
+    import connectors.httpParsers.ApprovalHttpParser.getApprovalSummaryListHttpReads
+
+    val summaryEndPoint: String = appConfig.externalGuidanceBaseUrl + "/external-guidance/approval/list"
+
+    httpClient.GET[RequestOutcome[List[ApprovalProcessSummary]]](summaryEndPoint, Seq.empty, Seq.empty)
+  }
 
   def submitForApproval(process: JsValue)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[RequestOutcome[ApprovalResponse]] = {
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,4 +1,5 @@
 service.name = External Guidance
+footer.links.accessibility.text=Accessibility
 
 approvals.tableTitle = Interactive Guidance
 approvals.processTitle = Title

--- a/it/pages/AdminControllerISpec.scala
+++ b/it/pages/AdminControllerISpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pages
+
+import models.errors.InvalidProcessError
+import play.api.http.Status
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.WSResponse
+import stubs.{AuditStub, ExternalGuidanceStub}
+import support.IntegrationSpec
+
+class AdminControllerISpec extends IntegrationSpec {
+
+  private val endPoint = "/process/approval"
+
+  "calling the approvalSummaries route" should {
+
+    "return an OK response" in {
+
+      AuditStub.audit()
+      val responsePayload: JsValue = Json
+        .parse(
+          """
+            |[
+            |  {
+            |    "id": "oct09092",
+            |    "title": "This is the title",
+            |    "lastUpdated": "2017-07-17",
+            |    "status": "SubmittedFor2iReview"
+            |  }
+            |]
+          """.stripMargin
+        )
+
+      ExternalGuidanceStub.approvalSummary(Status.OK, responsePayload)
+
+      val request = buildRequest(endPoint)
+      val response: WSResponse = await(request.get())
+      response.status shouldBe Status.OK
+
+    }
+    "return a BAD_REQUEST response when the external guidance microservice rejects an invalid process" in {
+
+      AuditStub.audit()
+
+      val responsePayload: JsValue = Json.toJson(InvalidProcessError)
+      ExternalGuidanceStub.approvalSummary(Status.OK, responsePayload)
+
+      val request = buildRequest(endPoint)
+      val response: WSResponse = await(request.get())
+      response.status shouldBe Status.BAD_REQUEST
+    }
+
+  }
+
+}

--- a/it/stubs/ExternalGuidanceStub.scala
+++ b/it/stubs/ExternalGuidanceStub.scala
@@ -24,6 +24,7 @@ object ExternalGuidanceStub extends WireMockMethods {
 
   private val saveScratchUri: String = s"/external-guidance/scratch"
   private val saveApprovalUri: String = s"/external-guidance/approval"
+  private val approvalSummaryUri: String = s"/external-guidance/approval/list"
 
   def saveScratch(status: Int, response: JsValue): StubMapping = {
     when(method = POST, uri = saveScratchUri)
@@ -32,6 +33,11 @@ object ExternalGuidanceStub extends WireMockMethods {
 
   def saveApproval(status: Int, response: JsValue): StubMapping = {
     when(method = POST, uri = saveApprovalUri)
+      .thenReturn(status, response)
+  }
+
+  def approvalSummary(status: Int, response: JsValue): StubMapping = {
+    when(method = GET, uri = approvalSummaryUri)
       .thenReturn(status, response)
   }
 

--- a/it/stubs/ExternalGuidanceStub.scala
+++ b/it/stubs/ExternalGuidanceStub.scala
@@ -24,7 +24,7 @@ object ExternalGuidanceStub extends WireMockMethods {
 
   private val saveScratchUri: String = s"/external-guidance/scratch"
   private val saveApprovalUri: String = s"/external-guidance/approval"
-  private val approvalSummaryUri: String = s"/external-guidance/approval/list"
+  private val approvalSummaryUri: String = s"/external-guidance/approval"
 
   def saveScratch(status: Int, response: JsValue): StubMapping = {
     when(method = POST, uri = saveScratchUri)

--- a/test/connectors/httpParsers/ApprovalHttpParserSpec.scala
+++ b/test/connectors/httpParsers/ApprovalHttpParserSpec.scala
@@ -16,10 +16,12 @@
 
 package connectors.httpParsers
 
+import java.time.LocalDate
+
 import base.BaseSpec
-import connectors.httpParsers.ApprovalHttpParser.saveApprovalHttpReads
+import connectors.httpParsers.ApprovalHttpParser._
 import models.errors.{InternalServerError, InvalidProcessError}
-import models.{RequestOutcome, ApprovalResponse}
+import models.{ApprovalProcessSummary, ApprovalResponse, ApprovalStatus, RequestOutcome}
 import play.api.http.{HttpVerbs, Status}
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.http.HttpResponse
@@ -79,4 +81,59 @@ class ApprovalHttpParserSpec extends BaseSpec with HttpVerbs with Status {
       result shouldBe Left(InternalServerError)
     }
   }
+
+  private trait SummaryTest {
+
+    val url: String = "/test"
+
+    val id: String = "oct90006"
+
+    val summaryListJson: JsValue = Json.parse("""
+        |[{
+        |  "id" : "oct90001",
+        |  "title" : "This is the title",
+        |  "status" : "SubmittedFor2iReview",
+        |  "lastUpdated" : "2017-07-17"
+        |}]
+      """.stripMargin)
+
+    val expectedResponse = List(ApprovalProcessSummary("oct90001", "This is the title", LocalDate.of(2017, 7, 17), ApprovalStatus.SubmittedFor2iReview))
+
+    val invalidResponse: JsValue = Json.obj() // no "id" property
+  }
+
+  "Parsing a successful summary response" should {
+
+    "return a valid approval response" in new SummaryTest {
+
+      private val httpResponse = HttpResponse(OK, Some(summaryListJson))
+      private val result = getApprovalSummaryListHttpReads.read(GET, url, httpResponse)
+      result shouldBe Right(expectedResponse)
+    }
+  }
+
+  "Parsing an error summary response" should {
+
+    "return an invalid process error for a bad request" in new SummaryTest {
+
+      val httpResponse: HttpResponse = HttpResponse(BAD_REQUEST)
+      private val result = getApprovalSummaryListHttpReads.read(GET, url, httpResponse)
+      result shouldBe Left(InvalidProcessError)
+    }
+
+    "return an internal server error for an invalid response" in new Test {
+
+      val httpResponse: HttpResponse = HttpResponse(OK, Some(invalidResponse))
+      private val result = getApprovalSummaryListHttpReads.read(GET, url, httpResponse)
+      result shouldBe Left(InternalServerError)
+    }
+
+    "return an internal server error when an error distinct from invalid process occurs" in new Test {
+
+      val httpResponse: HttpResponse = HttpResponse(SERVICE_UNAVAILABLE)
+      private val result = getApprovalSummaryListHttpReads.read(GET, url, httpResponse)
+      result shouldBe Left(InternalServerError)
+    }
+  }
+
 }

--- a/test/mocks/MockApprovalService.scala
+++ b/test/mocks/MockApprovalService.scala
@@ -31,7 +31,7 @@ trait MockApprovalService extends MockFactory {
 
   object MockApprovalService {
 
-    def approvalSummaries: CallHandler[Future[RequestOutcome[List[ApprovalProcessSummary]]]] =  
+    def approvalSummaries: CallHandler[Future[RequestOutcome[List[ApprovalProcessSummary]]]] =
       (mockApprovalService
         .approvalSummaries(_: ExecutionContext, _: HeaderCarrier))
         .expects(*, *)

--- a/test/models/ApprovalStatusSpec.scala
+++ b/test/models/ApprovalStatusSpec.scala
@@ -42,12 +42,12 @@ class ApprovalStatusSpec extends WordSpec with MustMatchers with OptionValues wi
       JsObject(Seq(("val", JsNull))).validate[ApprovalStatus] mustEqual JsError("error.invalid")
     }
 
-     "serialise" in {
+    "serialise" in {
 
-       for{
+      for {
         v <- ApprovalStatus.values
-       } yield Json.toJson(v) mustEqual JsString(v.toString)
+      } yield Json.toJson(v) mustEqual JsString(v.toString)
 
-     }
+    }
   }
 }

--- a/test/models/EnumerableSpec.scala
+++ b/test/models/EnumerableSpec.scala
@@ -44,11 +44,10 @@ class EnumerableSpec extends WordSpec with MustMatchers with EitherValues with O
       implicitly[Reads[Foo]]
     }
 
-    Foo.values.foreach {
-      value =>
-        s"bind correctly for: $value" in {
-          Json.fromJson[Foo](JsString(value.toString)).asEither.right.value mustEqual value
-        }
+    Foo.values.foreach { value =>
+      s"bind correctly for: $value" in {
+        Json.fromJson[Foo](JsString(value.toString)).asEither.right.value mustEqual value
+      }
     }
 
     "fail to bind for invalid values" in {
@@ -62,11 +61,10 @@ class EnumerableSpec extends WordSpec with MustMatchers with EitherValues with O
       implicitly[Writes[Foo]]
     }
 
-    Foo.values.foreach {
-      value =>
-        s"write $value" in {
-          Json.toJson(value) mustEqual JsString(value.toString)
-        }
+    Foo.values.foreach { value =>
+      s"write $value" in {
+        Json.toJson(value) mustEqual JsString(value.toString)
+      }
     }
   }
 

--- a/test/services/ApprovalServiceSpec.scala
+++ b/test/services/ApprovalServiceSpec.scala
@@ -79,11 +79,9 @@ class ApprovalServiceSpec extends BaseSpec {
       }
     }
 
-
     "Return a list of ManageProcesses after an successful call by the connector" in new Test {
 
-      MockApprovalConnector
-        .approvalSummaries
+      MockApprovalConnector.approvalSummaries
         .returns(Future.successful(Right(List())))
 
       val result: Future[RequestOutcome[List[ApprovalProcessSummary]]] = service.approvalSummaries
@@ -100,8 +98,7 @@ class ApprovalServiceSpec extends BaseSpec {
 
     "Return an error after an unsuccessful call to the connector by approvalSummaries" in new Test {
 
-      MockApprovalConnector
-        .approvalSummaries
+      MockApprovalConnector.approvalSummaries
         .returns(Future.successful(Left(InternalServerError)))
 
       val result: Future[RequestOutcome[List[ApprovalProcessSummary]]] = service.approvalSummaries


### PR DESCRIPTION
New code for the approval summary list connector and minor reformatting after scala fmt.  Relies on external-guidance pull request to work