### PR TITLE
EG-989 check when user reviews

### DIFF
--- a/app/connectors/httpParsers/HttpParser.scala
+++ b/app/connectors/httpParsers/HttpParser.scala
@@ -52,6 +52,7 @@ trait HttpParser {
         case Some(expectedError) => expectedError.code match {
           case NotFoundError.code => NotFoundError
           case StaleDataError.code => StaleDataError
+          case DuplicateKeyError.code => DuplicateKeyError
           case IncompleteDataError.code => IncompleteDataError
           case BadRequestError.code => BadRequestError
           case InvalidProcessError.code => InvalidProcessError

--- a/app/controllers/FactCheckController.scala
+++ b/app/controllers/FactCheckController.scala
@@ -19,13 +19,13 @@ package controllers
 import config.ErrorHandler
 import controllers.actions.FactCheckerIdentifierAction
 import javax.inject.{Inject, Singleton}
-import models.errors.{MalformedResponseError, NotFoundError, StaleDataError}
+import models.errors.{DuplicateKeyError, MalformedResponseError, NotFoundError, StaleDataError}
 import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.ReviewService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.fact_check_content_review
+import views.html.{duplicate_process_code_error, fact_check_content_review}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -34,6 +34,7 @@ class FactCheckController @Inject() (
     errorHandler: ErrorHandler,
     factCheckIdentifierAction: FactCheckerIdentifierAction,
     view: fact_check_content_review,
+    duplicate_process_code_error: duplicate_process_code_error,
     reviewService: ReviewService,
     mcc: MessagesControllerComponents
 ) extends FrontendController(mcc)
@@ -47,6 +48,9 @@ class FactCheckController @Inject() (
       case Left(NotFoundError) =>
         logger.error(s"Unable to retrieve approval fact check for process $id")
         NotFound(errorHandler.notFoundTemplate)
+      case Left(DuplicateKeyError) =>
+        logger.warn(s"Duplicate process code found when attempting to fact check process $id")
+        BadRequest(duplicate_process_code_error())
       case Left(StaleDataError) =>
         logger.warn(s"The requested approval fact check for process $id can no longer be found")
         NotFound(errorHandler.notFoundTemplate)

--- a/app/controllers/TwoEyeReviewResultController.scala
+++ b/app/controllers/TwoEyeReviewResultController.scala
@@ -30,7 +30,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.{AuditService, ReviewService}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.{twoeye_complete, twoeye_complete_error, twoeye_confirm_error, twoeye_review_result}
+import views.html.{duplicate_process_code_error, twoeye_complete, twoeye_confirm_error, twoeye_review_result}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -43,7 +43,7 @@ class TwoEyeReviewResultController @Inject() (
     view: twoeye_review_result,
     confirmation_view: twoeye_complete,
     errorView: twoeye_confirm_error,
-    publish_error_view: twoeye_complete_error,
+    publish_error_view: duplicate_process_code_error,
     reviewService: ReviewService,
     auditService: AuditService,
     mcc: MessagesControllerComponents

--- a/app/models/errors/Error.scala
+++ b/app/models/errors/Error.scala
@@ -44,3 +44,4 @@ object StaleDataError extends Error("STALE_DATA_ERROR", Some("The resource reque
 object MalformedResponseError extends Error("BAD_REQUEST", Some("The response received could not be parsed"), None)
 object BadRequestError extends Error("BAD_REQUEST_ERROR", Some("The request is invalid."), None)
 object IncompleteDataError extends Error("INCOMPLETE_DATA_ERROR", Some("Data is not in the required state for the requested action."), None)
+object DuplicateKeyError extends Error("DUPLICATE_KEY_ERROR", Some("An attempt was made to insert a duplicate key in the database."), None)

--- a/app/views/duplicate_process_code_error.scala.html
+++ b/app/views/duplicate_process_code_error.scala.html
@@ -18,12 +18,12 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@layout(s"${messages(s"2iReviewCompleteError.heading")} - ${messages("2iReview.heading")}") {
+@layout(s"${messages(s"duplicateProcessCodeError.heading")}") {
 
-  <h1 id="2i-error-heading" class="govuk-heading-xl">@messages(s"2iReviewCompleteError.heading")</h1>
-  <p id="2i-error-content" class="govuk-body">@messages(s"2iReviewCompleteError.reviewContent")</p>
-  <p id="2i-error-info" class="govuk-body">@messages(s"2iReviewCompleteError.info")</p>
-  <a id="2i-error-link" href="@{routes.AdminController.approvalSummaries.url}" role="button" class="govuk-button" data-module="govuk-button">@messages("2iReviewComplete.close")</a>
+  <h1 id="2i-error-heading" class="govuk-heading-xl">@messages(s"duplicateProcessCodeError.heading")</h1>
+  <p id="2i-error-content" class="govuk-body">@messages(s"duplicateProcessCodeError.reviewContent")</p>
+  <p id="2i-error-info" class="govuk-body">@messages(s"duplicateProcessCodeError.info")</p>
+  <a id="2i-error-link" href="@{routes.AdminController.approvalSummaries.url}" role="button" class="govuk-button" data-module="govuk-button">@messages("duplicateProcessCodeError.close")</a>
 }
 @{
  //$COVERAGE-OFF$

--- a/app/views/twoeye_complete_error.scala.html
+++ b/app/views/twoeye_complete_error.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(layout: main_layout)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@layout(s"${messages(s"2iReviewCompleteError.heading")} - ${messages("2iReview.heading")}") {
+
+  <h1 id="2i-error-heading" class="govuk-heading-xl">@messages(s"2iReviewCompleteError.heading")</h1>
+  <p id="2i-error-content" class="govuk-body">@messages(s"2iReviewCompleteError.reviewContent")</p>
+  <p id="2i-error-info" class="govuk-body">@messages(s"2iReviewCompleteError.info")</p>
+  <a id="2i-error-link" href="@{routes.AdminController.approvalSummaries.url}" role="button" class="govuk-button" data-module="govuk-button">@messages("2iReviewComplete.close")</a>
+}
+@{
+ //$COVERAGE-OFF$
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,7 +2,6 @@
 GET        /assets/*file                              controllers.Assets.versioned(path="/public", file: Asset)
 
 GET        /                                          controllers.AdminController.approvalSummaries
-#GET        /process/approval                          controllers.AdminController.approvalSummaries
 
 GET        /2i-review/:id                             controllers.TwoEyeReviewController.approval(id)
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -91,6 +91,11 @@ processReview.status = {0} of {1} pages reviewed
 2iReviewComplete.reviewContent = The content team will review your responses and contact you if they have any questions.
 2iReviewComplete.info = If you need to amend or add to the 2i review, contact the designer you''ve been working with.
 
+2iReviewCompleteError.title = Failed to publish guidance
+2iReviewCompleteError.heading = Failed to publish guidance
+2iReviewCompleteError.reviewContent = Another published guidance exists with the process code on this guidance - duplicates are not allowed.
+2iReviewCompleteError.info = Please contact the designer you''ve been working with to let them know there is a problem.
+
 2iReviewComplete.close = Return to dashboard
 
 factCheck.pageReviewStatus.NotStarted = Not checked

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -90,13 +90,13 @@ processReview.status = {0} of {1} pages reviewed
 2iReviewComplete.heading.Complete = Your responses have been shared with the content team
 2iReviewComplete.reviewContent = The content team will review your responses and contact you if they have any questions.
 2iReviewComplete.info = If you need to amend or add to the 2i review, contact the designer you''ve been working with.
-
-2iReviewCompleteError.title = Failed to publish guidance
-2iReviewCompleteError.heading = Failed to publish guidance
-2iReviewCompleteError.reviewContent = Another published guidance exists with the process code on this guidance - duplicates are not allowed.
-2iReviewCompleteError.info = Please contact the designer you''ve been working with to let them know there is a problem.
-
 2iReviewComplete.close = Return to dashboard
+
+duplicateProcessCodeError.title = Duplicate guidance process code found
+duplicateProcessCodeError.heading = Duplicate guidance process code found
+duplicateProcessCodeError.reviewContent = The system has found guidance which has been published with the process code on this guidance - duplicates are not allowed.
+duplicateProcessCodeError.info = Please contact the designer you''ve been working with to let them know there is a problem and that they will have to change the process code.
+duplicateProcessCodeError.close = Return to dashboard
 
 factCheck.pageReviewStatus.NotStarted = Not checked
 factCheck.pageReviewStatus.CompleteYes = Checked: factually accurate

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,16 +3,16 @@ import sbt._
 
 object AppDependencies {
   val compile = Seq(
-    "uk.gov.hmrc"             %% "play-language"            % "4.3.0-play-26",
-    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.14.0",
-    "uk.gov.hmrc"             %% "play-frontend-govuk"      % "0.49.0-play-26",
+    "uk.gov.hmrc"             %% "play-language"            % "4.4.0-play-26",
+    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.16.0",
+    "uk.gov.hmrc"             %% "play-frontend-govuk"      % "0.53.0-play-26",
     "uk.gov.hmrc"             %% "play-frontend-hmrc"       % "0.17.0-play-26",
-    "uk.gov.hmrc"             %% "auth-client"              % "3.0.0-play-26",
+    "uk.gov.hmrc"             %% "auth-client"              % "3.2.0-play-26",
     "uk.gov.hmrc"             %% "logback-json-logger"      % "4.8.0"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.14.0" % Test classifier "tests",
+    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.16.0" % Test classifier "tests",
     "org.scalamock"           %% "scalamock"                % "4.4.0"                 % "test",
     "org.scalatest"           %% "scalatest"                % "3.0.8"                 % "test",
     "org.jsoup"               %  "jsoup"                    % "1.10.2"                % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,9 +21,9 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.6.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.5.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/test/connectors/httpParsers/HttpParserSpec.scala
+++ b/test/connectors/httpParsers/HttpParserSpec.scala
@@ -46,6 +46,13 @@ class HttpParserSpec extends BaseSpec with HttpVerbs with Status with HttpParser
     }
   }
 
+  "Calling validateJson with invalid body" should {
+    "return None" in {
+      val response = HttpResponse(OK, "", Map.empty[String, Seq[String]])
+      response.validateJson[Person] shouldBe None
+    }
+  }
+
   "Calling validateJson with an invalid JSON response" should {
     "return None" in {
       val response = HttpResponse(OK, JsNull, Map.empty[String, Seq[String]])

--- a/test/connectors/httpParsers/ReviewHttpParserSpec.scala
+++ b/test/connectors/httpParsers/ReviewHttpParserSpec.scala
@@ -65,6 +65,11 @@ class ReviewHttpParserSpec extends WordSpec with Matchers with ReviewData {
         readResponse shouldBe Left(InternalServerError)
       }
     }
+    "the response is BAD_REQUEST with a code of DUPLICATE_KEY_ERROR" should {
+      "return StaleDataError" in new GetReviewDetailsSetup(BAD_REQUEST, Json.obj("code" -> "DUPLICATE_KEY_ERROR", "message" -> "")) {
+        readResponse shouldBe Left(DuplicateKeyError)
+      }
+    }
     "the response is anything else" should {
       "return InternalServerError" in new GetReviewDetailsSetup(INTERNAL_SERVER_ERROR, Json.obj("code" -> "INTERNAL_SERVER_ERROR", "message" -> "")) {
         readResponse shouldBe Left(InternalServerError)

--- a/test/controllers/FactCheckPageReviewControllerSpec.scala
+++ b/test/controllers/FactCheckPageReviewControllerSpec.scala
@@ -96,6 +96,13 @@ class FactCheckPageReviewControllerSpec extends ControllerBaseSpec with GuiceOne
       status(result) shouldBe Status.SEE_OTHER
     }
 
+    "Return BAD_REQUEST for a post of the review completion for a process without an answer" in new Test {
+
+      val result: Future[Result] = reviewController.onSubmit(id, updatedReviewDetail.pageUrl.drop(1), updatedReviewDetail.pageTitle, 1)(fakeRequest)
+
+      status(result) shouldBe Status.BAD_REQUEST
+    }
+
     "Return an Html document displaying the details of the review result" in new Test {
 
       MockReviewService

--- a/test/controllers/TwoEyePageReviewControllerSpec.scala
+++ b/test/controllers/TwoEyePageReviewControllerSpec.scala
@@ -85,6 +85,14 @@ class TwoEyePageReviewControllerSpec extends ControllerBaseSpec with GuiceOneApp
       status(result) shouldBe Status.SEE_OTHER
     }
 
+    "Return bad request when no data submitted" in new Test {
+
+      val result: Future[Result] = reviewController.onSubmit(id, updatedReviewDetail.pageUrl.drop(1), updatedReviewDetail.pageTitle, 1)(fakeRequest)
+
+      status(result) shouldBe Status.BAD_REQUEST
+    }
+
+
     "Return an Html document displaying the details of the review result" in new Test {
 
       MockReviewService

--- a/test/controllers/TwoEyeReviewResultControllerSpec.scala
+++ b/test/controllers/TwoEyeReviewResultControllerSpec.scala
@@ -36,7 +36,7 @@ import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
-import views.html.{twoeye_complete, twoeye_complete_error, twoeye_confirm_error, twoeye_review_result}
+import views.html.{duplicate_process_code_error, twoeye_complete, twoeye_confirm_error, twoeye_review_result}
 
 import scala.concurrent.Future
 
@@ -50,7 +50,7 @@ class TwoEyeReviewResultControllerSpec extends ControllerBaseSpec with GuiceOneA
     val view: twoeye_review_result = injector.instanceOf[twoeye_review_result]
     val confirmationView: twoeye_complete = injector.instanceOf[twoeye_complete]
     val errorView: twoeye_confirm_error = injector.instanceOf[twoeye_confirm_error]
-    val duplicateErrorView: twoeye_complete_error = injector.instanceOf[twoeye_complete_error]
+    val duplicateErrorView: duplicate_process_code_error = injector.instanceOf[duplicate_process_code_error]
     val formProvider: TwoEyeReviewResultFormProvider = new TwoEyeReviewResultFormProvider()
     val form: Form[ApprovalStatus] = formProvider()
 

--- a/test/controllers/TwoEyeReviewResultControllerSpec.scala
+++ b/test/controllers/TwoEyeReviewResultControllerSpec.scala
@@ -36,7 +36,7 @@ import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
-import views.html.{twoeye_complete, twoeye_confirm_error, twoeye_review_result}
+import views.html.{twoeye_complete, twoeye_complete_error, twoeye_confirm_error, twoeye_review_result}
 
 import scala.concurrent.Future
 
@@ -50,6 +50,7 @@ class TwoEyeReviewResultControllerSpec extends ControllerBaseSpec with GuiceOneA
     val view: twoeye_review_result = injector.instanceOf[twoeye_review_result]
     val confirmationView: twoeye_complete = injector.instanceOf[twoeye_complete]
     val errorView: twoeye_confirm_error = injector.instanceOf[twoeye_confirm_error]
+    val duplicateErrorView: twoeye_complete_error = injector.instanceOf[twoeye_complete_error]
     val formProvider: TwoEyeReviewResultFormProvider = new TwoEyeReviewResultFormProvider()
     val form: Form[ApprovalStatus] = formProvider()
 
@@ -65,6 +66,7 @@ class TwoEyeReviewResultControllerSpec extends ControllerBaseSpec with GuiceOneA
       view,
       confirmationView,
       errorView,
+      duplicateErrorView,
       mockReviewService,
       mockAuditService,
       messagesControllerComponents)
@@ -186,6 +188,19 @@ class TwoEyeReviewResultControllerSpec extends ControllerBaseSpec with GuiceOneA
 
       contentType(result) shouldBe Some(MimeTypes.HTML)
     }
+
+    "Return a bad request and display an error page when duplicate key detected" in new Test {
+
+      MockReviewService
+        .approval2iReviewComplete(id, credential, name, ApprovalStatus.Complete)
+        .returns(Future.successful(Left(DuplicateKeyError)))
+
+      val result: Future[Result] = reviewController.onSubmit(id)(fakePostRequest)
+
+      status(result) shouldBe Status.BAD_REQUEST
+      contentType(result) shouldBe Some(MimeTypes.HTML)
+    }
+
 
   }
 

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -64,6 +64,11 @@ class MappingsSpec extends BaseSpec with OptionValues with Mappings {
       val result = testForm.bind(Map.empty[String, String])
       result.errors should contain(FormError("value", "error.required"))
     }
+
+    "unbind a valid option" in {
+      val result = testForm.bind(Map("value" -> "B"))
+      result.get shouldEqual B
+    }
   }
 
 }

--- a/test/views/TwoEyeCompleteErrorViewSpec.scala
+++ b/test/views/TwoEyeCompleteErrorViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
-import views.html.twoeye_complete_error
+import views.html.duplicate_process_code_error
 
 class TwoEyeCompleteErrorViewSpec extends ViewSpecBase {
 
@@ -26,7 +26,7 @@ class TwoEyeCompleteErrorViewSpec extends ViewSpecBase {
 
     val processId = "ext90003"
 
-    val view: twoeye_complete_error = injector.instanceOf[twoeye_complete_error]
+    val view: duplicate_process_code_error = injector.instanceOf[duplicate_process_code_error]
 
     def createView: String => HtmlFormat.Appendable = _ => view()
 
@@ -35,16 +35,16 @@ class TwoEyeCompleteErrorViewSpec extends ViewSpecBase {
 
   "Following a duplicate error confirm error" should {
     "display the expected h1 tag" in new Test {
-      checkTextOnElementById(doc, "2i-error-heading", "2iReviewCompleteError.heading")
+      checkTextOnElementById(doc, "2i-error-heading", "duplicateProcessCodeError.heading")
     }
 
     "display the expected p tags" in new Test {
-      checkTextOnElementById(doc, "2i-error-content", "2iReviewCompleteError.reviewContent")
-      checkTextOnElementById(doc, "2i-error-info", "2iReviewCompleteError.info")
+      checkTextOnElementById(doc, "2i-error-content", "duplicateProcessCodeError.reviewContent")
+      checkTextOnElementById(doc, "2i-error-info", "duplicateProcessCodeError.info")
     }
 
     "display the back to dashboard button" in new Test {
-      checkTextOnElementById(doc, "2i-error-link", "2iReviewComplete.close")
+      checkTextOnElementById(doc, "2i-error-link", "duplicateProcessCodeError.close")
       checkAttributeOnElementById(doc, "2i-error-link", "role", "button")
       checkAttributeOnElementById(doc, "2i-error-link", "data-module", "govuk-button")
     }

--- a/test/views/TwoEyeCompleteErrorViewSpec.scala
+++ b/test/views/TwoEyeCompleteErrorViewSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import views.html.twoeye_complete_error
+
+class TwoEyeCompleteErrorViewSpec extends ViewSpecBase {
+
+  private trait Test {
+
+    val processId = "ext90003"
+
+    val view: twoeye_complete_error = injector.instanceOf[twoeye_complete_error]
+
+    def createView: String => HtmlFormat.Appendable = _ => view()
+
+    val doc: Document = asDocument(createView(processId))
+  }
+
+  "Following a duplicate error confirm error" should {
+    "display the expected h1 tag" in new Test {
+      checkTextOnElementById(doc, "2i-error-heading", "2iReviewCompleteError.heading")
+    }
+
+    "display the expected p tags" in new Test {
+      checkTextOnElementById(doc, "2i-error-content", "2iReviewCompleteError.reviewContent")
+      checkTextOnElementById(doc, "2i-error-info", "2iReviewCompleteError.info")
+    }
+
+    "display the back to dashboard button" in new Test {
+      checkTextOnElementById(doc, "2i-error-link", "2iReviewComplete.close")
+      checkAttributeOnElementById(doc, "2i-error-link", "role", "button")
+      checkAttributeOnElementById(doc, "2i-error-link", "data-module", "govuk-button")
+    }
+  }
+
+}


### PR DESCRIPTION
Extended check for duplicates that checks at the start of the review so a user does not have to go through the whole review process before they are told that it is a duplicate
This is the next stage of checking after the current PR for this change